### PR TITLE
fix a error with mocha test

### DIFF
--- a/api/users/test.js
+++ b/api/users/test.js
@@ -1,5 +1,6 @@
 
 var request = require('supertest');
+var should = require('should');
 var api = require('../..');
 
 describe('GET /users', function(){


### PR DESCRIPTION
When i run `mocha` in `./api/users`, i got some error
 ```
Uncaught TypeError: Cannot read property 'eql' of undefined
```
Here is my solve:
```
// (./api/users/test.js) add it
var should = require('should');
```